### PR TITLE
Add flatpak detection to disable DXVK

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,6 @@ A transparent wrapper for Roblox Player and Roblox Studio.
 # TODO
 + Add watchdog for unlocker in flatpak? This needs investigation.
 + Automatically kill wineprefix when Roblox has exited
-+ Better logging information
-+ Better log names
 + Fetch latest version of rbxfpsunlocker
 + Old death sounds (maybe)
 

--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ const (
 func usage() {
 	fmt.Println("usage: vinegar [delete|kill|reset]")
 	fmt.Println("       vinegar [player|studio] [args...]")
-	if !InFlatpak {
+	if !InFlatpak() {
 		fmt.Println("       vinegar [dxvk] install|uninstall")
 	}
 	os.Exit(1)
@@ -35,7 +35,7 @@ func main() {
 	case "delete":
 		DeleteDirs(Dirs.Data, Dirs.Cache)
 	case "dxvk":
-		if !inFlatpak {
+		if !InFlatpak() {
 			if argsCount < 2 {
 				usage()
 			}

--- a/main.go
+++ b/main.go
@@ -12,10 +12,12 @@ const (
 	STUDIOURL = "https://www.roblox.com/download/studio"
 )
 
+var InFlatpak bool = InFlatpakCheck()
+
 func usage() {
 	fmt.Println("usage: vinegar [delete|kill|reset]")
 	fmt.Println("       vinegar [player|studio] [args...]")
-	if !InFlatpak() {
+	if !InFlatpak {
 		fmt.Println("       vinegar [dxvk] install|uninstall")
 	}
 	os.Exit(1)
@@ -35,7 +37,11 @@ func main() {
 	case "delete":
 		DeleteDirs(Dirs.Data, Dirs.Cache)
 	case "dxvk":
-		if !InFlatpak() {
+			if InFlatpak {
+				fmt.Println("DXVK is managed automatically in the Flatpak and cannot be altered!")
+				//log not used because it wasn't imported yet
+				os.Exit(1)
+			}
 			if argsCount < 2 {
 				usage()
 			}
@@ -46,9 +52,6 @@ func main() {
 			case "uninstall":
 				DxvkUninstall()
 			}
-		} else {
-			fmt.Println("DXVK is already installed in the Flatpak and cannot be altered!")
-		}
 	case "exec":
 		Exec("wine", args[1:]...)
 	case "kill":

--- a/main.go
+++ b/main.go
@@ -15,7 +15,9 @@ const (
 func usage() {
 	fmt.Println("usage: vinegar [delete|kill|reset]")
 	fmt.Println("       vinegar [player|studio] [args...]")
-	fmt.Println("       vinegar [dxvk] install|uninstall")
+	if !InFlatpak {
+		fmt.Println("       vinegar [dxvk] install|uninstall")
+	}
 	os.Exit(1)
 }
 
@@ -33,15 +35,19 @@ func main() {
 	case "delete":
 		DeleteDirs(Dirs.Data, Dirs.Cache)
 	case "dxvk":
-		if argsCount < 2 {
-			usage()
-		}
+		if !inFlatpak {
+			if argsCount < 2 {
+				usage()
+			}
 
-		switch args[1] {
-		case "install":
-			DxvkInstall()
-		case "uninstall":
-			DxvkUninstall()
+			switch args[1] {
+			case "install":
+				DxvkInstall()
+			case "uninstall":
+				DxvkUninstall()
+			}
+		} else {
+			fmt.Println("DXVK is already installed in the Flatpak and cannot be altered!")
 		}
 	case "exec":
 		Exec("wine", args[1:]...)

--- a/main.go
+++ b/main.go
@@ -12,8 +12,6 @@ const (
 	STUDIOURL = "https://www.roblox.com/download/studio"
 )
 
-var InFlatpak bool = InFlatpakCheck()
-
 func usage() {
 	fmt.Println("usage: vinegar [delete|kill|reset]")
 	fmt.Println("       vinegar [player|studio] [args...]")

--- a/util.go
+++ b/util.go
@@ -114,7 +114,7 @@ func Unzip(source, target string) {
 }
 
 // Check if running in flatpak (in which case it is necessary to disable DXVK)
-func InFlatpak() bool {
+func InFlatpakCheck() bool {
 	if _, err := os.Stat("/.flatpak-info"); err != nil {
 		return false
 	} else {

--- a/util.go
+++ b/util.go
@@ -112,3 +112,12 @@ func Unzip(source, target string) {
 	Errc(os.RemoveAll(source))
 	log.Println("Removed archive", source)
 }
+
+// Check if running in flatpak (in which case it is necessary to disable DXVK)
+func InFlatpak() bool {
+	if file, err := os.Stat("/.flatpak-info"); err != nil {
+		return false
+	} else {
+		return true
+	}
+}

--- a/util.go
+++ b/util.go
@@ -13,6 +13,8 @@ import (
 	"time"
 )
 
+var InFlatpak bool = InFlatpakCheck()
+
 // Helper function to handle error failure
 func Errc(e error) {
 	if e != nil {

--- a/util.go
+++ b/util.go
@@ -115,7 +115,7 @@ func Unzip(source, target string) {
 
 // Check if running in flatpak (in which case it is necessary to disable DXVK)
 func InFlatpak() bool {
-	if file, err := os.Stat("/.flatpak-info"); err != nil {
+	if _, err := os.Stat("/.flatpak-info"); err != nil {
 		return false
 	} else {
 		return true


### PR DESCRIPTION
Since DXVK comes with flatpak (and installing more DXVK breaks it), we should add detection to it.